### PR TITLE
count_unmatchedというパラメータを追加してみました

### DIFF
--- a/lib/fluent/plugin/out_datacounter.rb
+++ b/lib/fluent/plugin/out_datacounter.rb
@@ -9,6 +9,7 @@ class Fluent::DataCounterOutput < Fluent::Output
   config_param :tag, :string, :default => 'datacount'
   config_param :input_tag_remove_prefix, :string, :default => nil
   config_param :count_key, :string
+  config_param :count_unmatched, :bool, :default => true
 
   # pattern0 reserved as unmatched counts
   config_param :pattern1, :string # string: NAME REGEXP
@@ -185,7 +186,7 @@ class Fluent::DataCounterOutput < Fluent::Output
         matched = true
         break
       end
-      c[0] += 1 unless matched
+      c[0] += 1 if not matched and @count_unmatched
     end
     countups(tag, c)
 

--- a/test/plugin/test_out_datacounter.rb
+++ b/test/plugin/test_out_datacounter.rb
@@ -272,6 +272,30 @@ class DataCounterOutputTest < Test::Unit::TestCase
     assert_equal 0, data[2]['unmatched_count']
     assert_equal 0.0, data[2]['unmatched_rate']
     assert_equal 0.0, data[2]['unmatched_percentage']
+
+    d3 = create_driver(%[
+      aggregate all
+      count_key target
+      count_unmatched false
+      pattern1 ok 2\\d\\d
+    ], 'test.tag3')
+    d3.run do
+      60.times do
+        d3.emit({'target' => '200'})
+        d3.emit({'target' => '300'})
+      end
+    end
+    d3.instance.flush_emit(120)
+    emits = d3.emits
+    assert_equal 1, emits.length
+    data = emits[0]
+    assert_equal 'datacount', data[0] # tag
+    assert_equal 60, data[2]['ok_count']
+    assert_equal 0.5, data[2]['ok_rate']
+    assert_equal 100.0, data[2]['ok_percentage']
+    assert_equal 0, data[2]['unmatched_count']
+    assert_equal 0.0, data[2]['unmatched_rate']
+    assert_equal 0.0, data[2]['unmatched_percentage']
   end
 
 end


### PR DESCRIPTION
unmatched なログを percentage に入れたくない場合があったので、count_unmatched false という指定で unmached のものは数に含めない設定ができるようにしましたがどうでしょうか。
