### PR TITLE
add auto_key settings (without pattern#{i})

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -10,6 +10,14 @@
   add_prefix sampled
 </match>
 
+<match sampledall.**>
+  type datacounter
+  tag result
+  aggregate all
+  count_key field
+  count_all_patterns
+</match>
+
 <match sampled.**>
   type datacounter
   tag result


### PR DESCRIPTION
おそらく、データサイズが無制限に増えるのを抑制するためにpatternを明示的に定義するようにしたとは思うのですが、patternが無いほうが助かるケースがあったので変更しました。
