### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# fluent-plugin-datacounter, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-datacounter
+
+This is a plugin for [Fluentd](http://fluentd.org)
 
 ## Component
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
