### PR TITLE
update requirement version to 0.14.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is a plugin for [Fluentd](http://fluentd.org)
 
 ## Requirements
 
-| fluent-plugin-datacounter | fluentd    | ruby   |
-|---------------------------|------------|--------|
-| >= 1.0.0                  | >= v0.14.8 | >= 2.1 |
-| <  1.0.0                  | <  v0.14.0 | >= 1.9 |
+| fluent-plugin-datacounter | fluentd     | ruby   |
+|---------------------------|-------------|--------|
+| >= 1.0.0                  | >= v0.14.12 | >= 2.1 |
+| <  1.0.0                  | <  v0.14.0  | >= 1.9 |
 
 ## Component
 
@@ -111,7 +111,7 @@ And you can get tested messages count with 'output_messages' option:
     </match>
     # => tag: 'datacount'
     #    message: {'foo_messages' => xxx, 'foo_OK_count' => ... }
-    
+
     <match accesslog.baz>
       @type datacounter
       count_key status
@@ -137,7 +137,7 @@ And you can get tested messages count with 'output_messages' option:
 
 * tag\_prefix
 
-    The prefix string which will be added to the input tag. `output_per_tag yes` must be specified together. 
+    The prefix string which will be added to the input tag. `output_per_tag yes` must be specified together.
 
 * input\_tag\_remove\_prefix
 

--- a/fluent-plugin-datacounter.gemspec
+++ b/fluent-plugin-datacounter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
+  gem.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
`system_config.workers` ( https://github.com/tagomoris/fluent-plugin-datacounter/blob/master/lib/fluent/plugin/out_datacounter.rb#L108 ) was added in fluentd 0.14.12 ( https://github.com/fluent/fluentd/blob/v0.14.12/lib/fluent/system_config.rb#L32 ).